### PR TITLE
Fix for 0.15.10

### DIFF
--- a/5dim_core_0.15.2/prototypes/item-group-changes.lua
+++ b/5dim_core_0.15.2/prototypes/item-group-changes.lua
@@ -230,12 +230,14 @@ data.raw.recipe["lubricant"].subgroup = "liquid-recipe"
 data.raw.recipe["coal-liquefaction"].subgroup = "liquid-recipe"
 -- Barreling
 for _,fluid in pairs(data.raw.fluid) do
-	local barrel = fluid.name .. "-barrel"
-	local fill = "fill-" .. fluid.name .. "-barrel"
-	local empty = "empty-" .. fluid.name .. "-barrel"
-	data.raw.item[barrel].subgroup = "liquid-item"
-	data.raw.recipe[fill].subgroup = "liquid-fill"
-	data.raw.recipe[empty].subgroup = "liquid-empty"
+	if fluid.name ~= "steam" then
+		local barrel = fluid.name .. "-barrel"
+		local fill = "fill-" .. fluid.name .. "-barrel"
+		local empty = "empty-" .. fluid.name .. "-barrel"
+		data.raw.item[barrel].subgroup = "liquid-item"
+		data.raw.recipe[fill].subgroup = "liquid-fill"
+		data.raw.recipe[empty].subgroup = "liquid-empty"
+	end
 end
 
 --Logistic

--- a/5dim_energy_0.15.1/prototypes/boilers-2.lua
+++ b/5dim_energy_0.15.1/prototypes/boilers-2.lua
@@ -112,6 +112,16 @@ data:extend({
       },
       production_type = "output"
     },
+    fluid_input =
+    {
+      name = "water",
+      amount = 0.0
+    },
+    fluid_output =
+    {
+      name = "steam",
+      amount = 0.0
+    },
     energy_consumption = "1.8MW",
     energy_source =
     {

--- a/5dim_energy_0.15.1/prototypes/boilers-3.lua
+++ b/5dim_energy_0.15.1/prototypes/boilers-3.lua
@@ -111,6 +111,16 @@ data:extend({
       },
       production_type = "output"
     },
+    fluid_input =
+    {
+      name = "water",
+      amount = 0.0
+    },
+    fluid_output =
+    {
+      name = "steam",
+      amount = 0.0
+    },
     energy_consumption = "1.8MW",
     energy_source =
     {


### PR DESCRIPTION
Hello,

This is a fix for #8 

According to the[ changelog](http://store.steampowered.com/news/externalpost/steam_community_announcements/18761):
> Steam is now internally a separate fluid from hot water.

There is no barrel for steam and the boiler need to know the input and ouput fluid. I use the default values from demo-entities.lua

I try in advanced save and this works fine
