### PR TITLE
heat exchanger outputs heated water and no steam Fix

### DIFF
--- a/Factorio 0.16.X/5dim_nuclear_0.16.2/prototypes/heat-exchanger.lua
+++ b/Factorio 0.16.X/5dim_nuclear_0.16.2/prototypes/heat-exchanger.lua
@@ -75,7 +75,8 @@ data:extend({
       {
         {type = "output", position = {0, -1.5}}
       },
-      production_type = "output"
+      production_type = "output",
+      filter = "steam"
     },
     fluid_input =
     {


### PR DESCRIPTION
it did output water at 500ºc without the filter at the output, now it outputs steam.
 The filter was missing from the vanilla prototype.