### PR TITLE
Fire animation misalignment fix

### DIFF
--- a/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/coal-furnace-3.lua
+++ b/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/coal-furnace-3.lua
@@ -95,7 +95,7 @@ data:extend({
           width = 36,
           height = 19,
           frame_count = 12,
-          shift = { 0.0625, 0.375}
+          shift = { -0.0625, 0.65625}
         },
         light = {intensity = 1, size = 1}
       }

--- a/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/masher-2.lua
+++ b/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/masher-2.lua
@@ -76,7 +76,7 @@ data:extend({
           width = 36,
           height = 19,
           frame_count = 12,
-          shift = { 0.0625, 0.375}
+          shift = { -0.0625, 0.65625}
         },
         light = {intensity = 1, size = 1}
       }

--- a/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/masher.lua
+++ b/Factorio 0.16.X/5dim_resources_0.16.5/prototypes/masher.lua
@@ -75,7 +75,7 @@ data:extend({
           width = 36,
           height = 19,
           frame_count = 12,
-          shift = { 0.0625, 0.375}
+          shift = { -0.0625, 0.65625}
         },
         light = {intensity = 1, size = 1}
       }


### PR DESCRIPTION
Coal Furnance 3, masher and masher 2 had the fire animation in the wrong place.
original shift -> http://steamcommunity.com/sharedfiles/filedetails/?id=1263633019
result-> http://steamcommunity.com/sharedfiles/filedetails/?id=1263628546