### PR TITLE
Fix for Issue 59

### DIFF
--- a/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-2.lua
+++ b/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-2.lua
@@ -20,7 +20,7 @@ data:extend({
     energy_required = 2,
     ingredients =
     {
-      {"5d-mining-drill-range-1", 1},
+      {"5d-mining-drill-speed-2", 1},
       {"steel-plate", 10},
       {"advanced-circuit", 2},
     },

--- a/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-3.lua
+++ b/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-3.lua
@@ -20,7 +20,7 @@ data:extend({
     energy_required = 2,
     ingredients =
     {
-      {"5d-mining-drill-range-2", 1},
+      {"5d-mining-drill-speed-2", 1},
       {"steel-plate", 15},
       {"processing-unit", 10},
     },


### PR DESCRIPTION
Speed drill recipes contain range drills.
Speed drill mk2 asks for -> RANGE drill mk1
Speed ddrill mk3 asks for -> RANGE  drill mk2

This changes leave the recipes like this:
Speed drill mk2 asks for -> Speed drill mk1
Speed ddrill mk3 asks for -> Speed  drill mk2

Please comment if this is intended or just a typo : 3
Issue linked
https://github.com/McGuten/5DimsFactorioMods/issues/59