### PR TITLE
Recipe for mining drills

### DIFF
--- a/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-2.lua
+++ b/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-2.lua
@@ -20,7 +20,7 @@ data:extend({
     energy_required = 2,
     ingredients =
     {
-      {"5d-mining-drill-range-1", 1},
+      {"5d-mining-drill-speed-1", 1},
       {"steel-plate", 10},
       {"advanced-circuit", 2},
     },

--- a/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-3.lua
+++ b/Factorio 0.16.X/5dim_mining_0.16.6/prototypes/mining-speed-3.lua
@@ -20,7 +20,7 @@ data:extend({
     energy_required = 2,
     ingredients =
     {
-      {"5d-mining-drill-range-2", 1},
+      {"5d-mining-drill-speed-2", 1},
       {"steel-plate", 15},
       {"processing-unit", 10},
     },


### PR DESCRIPTION
Mining SPEED drills tier 2, and 3 are crafted with RANGE drills tier 1 and 2.
Before ->range1->SPEED2 || range2->SPEED3
I changed the recipes to a streight upgrade path, speed 1-> speed2 -> speed3
Fixes this issue if it was not intended.
https://github.com/McGuten/5DimsFactorioMods/issues/59