### PR TITLE
0.16.17 updates 

### DIFF
--- a/Factorio 0.16.X/5dim_automatization_0.16.4/changelog.txt
+++ b/Factorio 0.16.X/5dim_automatization_0.16.4/changelog.txt
@@ -3,3 +3,8 @@ Version: 0.16.4
 Date: 06/01/2018
   News:
     - Added changelog.txt.
+---------------------------------------------------------------------------------------------------
+Version: 0.16.5
+Date: 23/01/2018
+  News:
+    - Adjusted chemical-plant mk2/3 collision to match balance changes.

--- a/Factorio 0.16.X/5dim_automatization_0.16.4/prototypes/chemical-plant-2.lua
+++ b/Factorio 0.16.X/5dim_automatization_0.16.4/prototypes/chemical-plant-2.lua
@@ -39,7 +39,7 @@ data:extend({
   max_health = 300,
   corpse = "big-remnants",
   dying_explosion = "medium-explosion",
-  collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
+  collision_box = {{-1.2, -1.2}, {1.2, 1.2}},
   selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
   fast_replaceable_group = "chemical-plant",
   module_specification =

--- a/Factorio 0.16.X/5dim_automatization_0.16.4/prototypes/chemical-plant-3.lua
+++ b/Factorio 0.16.X/5dim_automatization_0.16.4/prototypes/chemical-plant-3.lua
@@ -39,7 +39,7 @@ data:extend({
   max_health = 300,
   corpse = "big-remnants",
   dying_explosion = "medium-explosion",
-  collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
+  collision_box = {{-1.2, -1.2}, {1.2, 1.2}},
   selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
   fast_replaceable_group = "chemical-plant",
   module_specification =

--- a/Factorio 0.16.X/5dim_nuclear_0.16.4/changelog.txt
+++ b/Factorio 0.16.X/5dim_nuclear_0.16.4/changelog.txt
@@ -3,3 +3,8 @@ Version: 0.16.3
 Date: 06/01/2018
   Changes:
     - Added changelog.txt.
+---------------------------------------------------------------------------------------------------
+Version: 0.16.4
+Date: 23/01/2018
+  Changes:
+    - Steam Turbine fast-replace fix.

--- a/Factorio 0.16.X/5dim_nuclear_0.16.4/prototypes/changes.lua
+++ b/Factorio 0.16.X/5dim_nuclear_0.16.4/prototypes/changes.lua
@@ -1,4 +1,3 @@
 data.raw["assembling-machine"]["centrifuge"].fast_replaceable_group = "centrifuge"
 data.raw["boiler"]["heat-exchanger"].fast_replaceable_group = "heat-exchanger"
 data.raw["reactor"]["nuclear-reactor"].fast_replaceable_group = "nuclear-reactor"
-data.raw["generator"]["steam-turbine"].fast_replaceable_group = "steam-turbine"

--- a/Factorio 0.16.X/5dim_nuclear_0.16.4/prototypes/turbine.lua
+++ b/Factorio 0.16.X/5dim_nuclear_0.16.4/prototypes/turbine.lua
@@ -30,7 +30,7 @@ data:extend({
     minable = {mining_time = 1, result = "5d-steam-turbine-2"},
     icon_size = 32,
     max_health = 300,
-    fast_replaceable_group = "steam-turbine",
+    fast_replaceable_group = "steam-engine",
     corpse = "big-remnants",
     dying_explosion = "medium-explosion",
     effectivity = 1.1,
@@ -43,7 +43,6 @@ data:extend({
         percent = 70
       }
     },
-    fast_replaceable_group = "steam-engine",
     collision_box = {{-1.35, -2.35}, {1.35, 2.35}},
     selection_box = {{-1.5, -2.5}, {1.5, 2.5}},
     fluid_box =

--- a/Factorio 0.16.X/5dim_transport_0.16.5/changelog.txt
+++ b/Factorio 0.16.X/5dim_transport_0.16.5/changelog.txt
@@ -3,3 +3,8 @@ Version: 0.16.5
 Date: 06/01/2018
   Changes:
     - Added changelog.txt.
+---------------------------------------------------------------------------------------------------
+Version: 0.16.6
+Date: 23/01/2018
+  Changes:
+    - Updated splitters to match vanilla scaling.

--- a/Factorio 0.16.X/5dim_transport_0.16.5/prototypes/splitter-4.lua
+++ b/Factorio 0.16.X/5dim_transport_0.16.5/prototypes/splitter-4.lua
@@ -108,7 +108,7 @@ data:extend({
     flags = {"placeable-neutral", "player-creation"},
     minable = {hardness = 0.2, mining_time = 0.5, result = "5d-mk4-splitter"},
     icon_size = 32,
-    max_health = 80,
+    max_health = 200,
     corpse = "medium-remnants",
     resistances =
     {
@@ -131,7 +131,7 @@ data:extend({
     starting_bottom = mk4_belt_starting_bottom,
     starting_side = mk4_belt_starting_side,
     ending_patch = ending_patch_prototype,
-    fast_replaceable_group = "splitter",
+    fast_replaceable_group = "transport-belt",
     speed = 0.125,
     structure =
     {

--- a/Factorio 0.16.X/5dim_transport_0.16.5/prototypes/splitter-5.lua
+++ b/Factorio 0.16.X/5dim_transport_0.16.5/prototypes/splitter-5.lua
@@ -108,7 +108,7 @@ data:extend({
     flags = {"placeable-neutral", "player-creation"},
     minable = {hardness = 0.2, mining_time = 0.5, result = "5d-mk5-splitter"},
     icon_size = 32,
-    max_health = 80,
+    max_health = 210,
     corpse = "medium-remnants",
     resistances =
     {
@@ -131,7 +131,7 @@ data:extend({
     starting_bottom = mk5_belt_starting_bottom,
     starting_side = mk5_belt_starting_side,
     ending_patch = ending_patch_prototype,
-    fast_replaceable_group = "splitter",
+    fast_replaceable_group = "transport-belt",
     speed = 0.15625,
     structure =
     {


### PR DESCRIPTION
Mk4/5 splitters have the same fast-replace group as the 3 vanilla ones.
      "splitter" Now-> "transport-belt"
Mk4/5 splitters hp scaling to match vanilla
      200/210 to match (+10) upgrade steps from vanilla
Vanilla and 5dim's steam-turbine have now the same fast-replace group (vanilla).
     can't fast-replace steam-engines with vanilla's turbine Now  -> you can.

Turbine changes tested.
Vanilla, turbine replacing steam-engine (this was broken by the changes.lua)
http://steamcommunity.com/sharedfiles/filedetails/?id=1278585186
5dim's turbine can now replace any steam engine.
http://steamcommunity.com/sharedfiles/filedetails/?id=1278585343
5dim's turbine
http://steamcommunity.com/sharedfiles/filedetails/?id=1278585441
vanilla, no mods mod listed
http://steamcommunity.com/sharedfiles/filedetails/?id=1278585565