### PR TITLE
Remove non-on-map flag from vehicles and trains

### DIFF
--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/high-speed-locomotive.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/high-speed-locomotive.lua
@@ -30,7 +30,7 @@ data:extend({
   type = "locomotive", 
   name = "5d-locomotive-hs", 
   icon = "__5dim_trains__/graphics/diesel-locomotive2.png", 
-  flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+  flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
   minable = {mining_time = 1, result = "5d-locomotive-hs"}, 
   icon_size = 32,
   mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"}, 

--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/liquid-2.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/liquid-2.lua
@@ -32,7 +32,7 @@ data:extend({
     type = "fluid-wagon", 
     name = "5d-fluid-wagon-2", 
     icon = "__5dim_trains__/graphics/fluid-wagon2.png", 
-    flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+    flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
     minable = {mining_time = 1, result = "5d-fluid-wagon-2"}, 
     icon_size = 32,
     mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"}, 

--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/liquid-3.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/liquid-3.lua
@@ -32,7 +32,7 @@ data:extend({
     type = "fluid-wagon", 
     name = "5d-fluid-wagon-3", 
     icon = "__5dim_trains__/graphics/fluid-wagon3.png", 
-    flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+    flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
     minable = {mining_time = 1, result = "5d-fluid-wagon-3"}, 
     icon_size = 32,
     mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"}, 

--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/reinforced-locomotive.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/reinforced-locomotive.lua
@@ -30,7 +30,7 @@ data:extend({
   type = "locomotive", 
   name = "5d-locomotive-reinforced", 
   icon = "__5dim_trains__/graphics/reinforced/icon.png", 
-  flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+  flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
   minable = {mining_time = 1, result = "5d-locomotive-reinforced"}, 
   icon_size = 32,
   mined_sound = {filename = "__core__/sound/deconstruct-medium.ogg"}, 

--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/wagon-2.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/wagon-2.lua
@@ -30,7 +30,7 @@ data:extend({
     type = "cargo-wagon", 
     name = "5d-cargo-wagon-2", 
     icon = "__5dim_trains__/graphics/cargo-wagon2.png", 
-    flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+    flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
     icon_size = 32,
     inventory_size = 80, 
     fast_replaceable_group = "cargo-wagon",

--- a/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/wagon-3.lua
+++ b/Factorio 0.16.X/5dim_trains_0.16.6/prototypes/wagon-3.lua
@@ -30,7 +30,7 @@ data:extend({
     type = "cargo-wagon", 
     name = "5d-cargo-wagon-3", 
     icon = "__5dim_trains__/graphics/cargo-wagon3.png", 
-    flags = {"placeable-neutral", "player-creation", "placeable-off-grid", "not-on-map"}, 
+    flags = {"placeable-neutral", "player-creation", "placeable-off-grid"}, 
     icon_size = 32,
     inventory_size = 120, 
     fast_replaceable_group = "cargo-wagon",

--- a/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/air-plane.lua
+++ b/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/air-plane.lua
@@ -31,7 +31,7 @@ data:extend({
     type = "car",
     name = "5d-air-plane",
     icon = "__5dim_vehicle__/graphics/icon/air-plane/air-plane.png",
-    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid", "not-on-map"},
+    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid"},
     minable = {mining_time = 1, result = "5d-air-plane"},
     icon_size = 32,
     max_health = 150,

--- a/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/boat.lua
+++ b/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/boat.lua
@@ -31,7 +31,7 @@ data:extend({
     type = "car",
     name = "5d-boat",
     icon = "__5dim_vehicle__/graphics/icon/barco_.png",
-    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid", "not-on-map"},
+    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid"},
     minable = {mining_time = 1, result = "5d-boat"},
     icon_size = 32,
     max_health = 300,

--- a/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/truck.lua
+++ b/Factorio 0.16.X/5dim_vehicle_0.16.4/prototypes/truck.lua
@@ -31,7 +31,7 @@ data:extend({
     type = "car",
     name = "5d-truck",
     icon = "__5dim_vehicle__/graphics/icon/truck/truck.png",
-    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid", "not-on-map"},
+    flags = {"pushable", "placeable-neutral", "player-creation","placeable-off-grid"},
     minable = {mining_time = 1, result = "5d-truck"},
     icon_size = 32,
     max_health = 800,


### PR DESCRIPTION
This flag hides vehicles and trains on map since 0.16.29.

> Fixed that vehicles and train stops wouldn't respect the "not-on-map" flag.