### PR TITLE
Base no longer provides 'gate1.ogg'.

### DIFF
--- a/Factorio 0.18.X/5dim_battlefield_0.18.1/prototypes/gate.lua
+++ b/Factorio 0.18.X/5dim_battlefield_0.18.1/prototypes/gate.lua
@@ -406,7 +406,7 @@ data:extend({
     vehicle_impact_sound =  { filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
     open_sound =
     {
-      variations = { filename = "__base__/sound/gate1.ogg", volume = 0.5 },
+      variations = { filename = "__base__/sound/gate-open-1.ogg", volume = 0.5 },
       aggregation =
       {
         max_count = 1,
@@ -415,7 +415,7 @@ data:extend({
     },
     close_sound =
     {
-      variations = { filename = "__base__/sound/gate1.ogg", volume = 0.5 },
+      variations = { filename = "__base__/sound/gate-close-1.ogg", volume = 0.5 },
       aggregation =
       {
         max_count = 1,


### PR DESCRIPTION
They seem to be split into gate-open-*.ogg and gate-close-*.ogg.

I was trying to start out an 0.18 5dims run, not having played 5dims before. I ran into an error during loading. This at least fixes the loading error for me, I don't know if any other changes are needed.
